### PR TITLE
fix: Change broken SLO link in Monitoring section

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Contributions are always welcome!
 
 ## Monitoring
 
-- [ ] [SLOs & You: A Guide To Service Level Objectives](https://www.circonus.com/2018/07/a-guide-to-service-level-objectives)
 - [ ] [Setting up Service Monitoring — The Why’s and What’s](https://amitosh.medium.com/the-whys-and-what-s-of-setting-up-service-monitoring-cc1c165ee088)
 - [ ] [How NOT to Measure Latency](https://youtu.be/lJ8ydIuPFeU)
 - [ ] [The four Golden Signals of Kubernetes monitoring](https://sysdig.com/blog/golden-signals-kubernetes)

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Contributions are always welcome!
 
 ## Monitoring
 
+- [ ] [Implementing SLOs](https://sre.google/workbook/implementing-slos/)
 - [ ] [Setting up Service Monitoring — The Why’s and What’s](https://amitosh.medium.com/the-whys-and-what-s-of-setting-up-service-monitoring-cc1c165ee088)
 - [ ] [How NOT to Measure Latency](https://youtu.be/lJ8ydIuPFeU)
 - [ ] [The four Golden Signals of Kubernetes monitoring](https://sysdig.com/blog/golden-signals-kubernetes)


### PR DESCRIPTION
Hey! I saw that the changed link was broken and leading to a commercial page with no blog post whatsoever. Doing some Google searches, I have found this to be the most relevant in such domain.

Feel free to modify!

Thanks!