### PR TITLE
Update [Demystifying the Kubernetes Iceberg] link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Contributions are always welcome!
 ## Kubernetes
 
 - [ ] [Deploying and Scaling Microservices with Docker and Kubernetes](http://container.training/kube-selfpaced.yml.html)
-- [ ] [Demystifying the Kubernetes Iceberg](https://asankov.dev/blog/2022/05/15/demystifying-the-kubernetes-iceberg-part-1)
+- [ ] [Demystifying the Kubernetes Iceberg](https://asankov.dev/post/demystifying-the-kubernetes-iceberg-1)
 - [ ] [What happens when ... Kubernetes edition!](https://github.com/jamiehannaford/what-happens-when-k8s/blob/master/README.md)
 - [ ] [Kubernetes Production Patterns](https://github.com/gravitational/workshop/blob/master/k8sprod.md)
 - [ ] [Kubernetes production best practices](https://learnk8s.io/production-best-practices)


### PR DESCRIPTION
When trying to access the link provided in the README file, it shows a 404 error. Upon inspection, I found that Anton has updated the blog link.