### PR TITLE
Add hands-on Linux labs resource to Linux section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Contributions are always welcome!
 - [ ] [What every SRE should know about GNU/Linux shell related internals: file descriptors, pipes, terminals, user sessions, process groups and daemons](https://biriukov.dev/docs/fd-pipe-session-terminal/0-sre-should-know-about-gnu-linux-shell-related-internals-file-descriptors-pipes-terminals-user-sessions-process-groups-and-daemons)
 - [ ] [SRE deep dive into Linux Page Cache](https://biriukov.dev/docs/page-cache/0-linux-page-cache-for-sre)
 - [ ] [Linux Internals workshop - Google TechTalks](https://www.youtube.com/playlist?list=PLSIUOFhnxEiC3YTdxwqZqgEY5imVL8U8J)
+- [ ] [Linux for Noobs (Hands-On Labs)](https://labex.io/courses/linux-for-noobs)
 
 ### Boot Process
 


### PR DESCRIPTION
## Summary

Add [Linux for Noobs (Hands-On Labs)](https://labex.io/courses/linux-for-noobs) under Linux.

Completed the full course during interview prep. Hands-on labs helped me retain basics (file ops, permissions, processes, etc.) better than passive video/tutorial formats. All core labs are free.

Follows CONTRIBUTING.md: no duplicate, relevant to SRE Linux prep, standard list format.